### PR TITLE
Add possibility of setting the path to Sublime Merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,14 @@ All commands are available in the Command Palette and Context Menus for the Expl
 ext install adhamu.history-in-sublime-merge
 ```
 
-## Requirements
+## Requirements for Windows
 
 Ensure the `smerge` command is in your `$PATH`.
 
 [Details can be found here](https://www.sublimemerge.com/docs/command_line)
+
+## Settings
+
+### `history-in-sublime-merge.path`
+
+Edit this value to override the path to Sublime Merge. When not set, the default path, depending on the operating system, is used.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All commands are available in the Command Palette and Context Menus for the Expl
 ext install adhamu.history-in-sublime-merge
 ```
 
-## Requirements for Windows
+## Requirements
 
 Ensure the `smerge` command is in your `$PATH`.
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,18 @@
           "group": "YourGroup@3"
         }
       ]
-    }
+    },
+    "configuration": [
+      {
+        "title": "History in Sublime Merge",
+        "properties": {
+          "history-in-sublime-merge.path": {
+            "type": "string",
+            "markdownDescription": "Path to Sublime Merge. When not set, the default path, depending on the operating system, is used."
+          }
+        }
+      }
+    ]
   },
   "activationEvents": [
     "onCommand:history-in-sublime-merge.viewFileHistory",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,12 +25,7 @@ const openSublimeMerge = (args: string[], repository: string): void => {
     .getConfiguration()
     .get('history-in-sublime-merge.path');
 
-  const path =
-    typeof customPath === 'string' && customPath
-      ? customPath
-      : SMERGE_BINARY_PATH;
-
-  child.execFile(path, args, {
+  child.execFile(customPath || SMERGE_BINARY_PATH, args, {
     cwd: repository,
   });
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ const getCurrentRepository = async (file: string): Promise<string> => {
 const openSublimeMerge = (args: string[], repository: string): void => {
   const customPath = vscode.workspace
     .getConfiguration()
-    .get('history-in-sublime-merge.path');
+    .get<string>('history-in-sublime-merge.path');
 
   child.execFile(customPath || SMERGE_BINARY_PATH, args, {
     cwd: repository,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,16 @@ const getCurrentRepository = async (file: string): Promise<string> => {
 };
 
 const openSublimeMerge = (args: string[], repository: string): void => {
-  child.execFile(SMERGE_BINARY_PATH, args, {
+  const customPath = vscode.workspace
+    .getConfiguration()
+    .get('history-in-sublime-merge.path');
+
+  const path =
+    typeof customPath === 'string' && customPath
+      ? customPath
+      : SMERGE_BINARY_PATH;
+
+  child.execFile(path, args, {
     cwd: repository,
   });
 };


### PR DESCRIPTION
Addresses https://github.com/adhamu/history-in-sublime-merge/issues/15

This adds the extension setting `history-in-sublime-merge.path`, which allows to override the path to Sublime Merge:

![image](https://github.com/adhamu/history-in-sublime-merge/assets/29386932/29c84e2c-4829-4d06-b34a-4e2ba26c94bf)
