### PR TITLE
Create commend "Open repository in Sublime Merge"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
   "contributes": {
     "commands": [
       {
+        "command": "history-in-sublime-merge.openRepository",
+        "title": "Open repository in Sublime Merge",
+        "category": "Sublime Merge"
+      },
+      {
         "command": "history-in-sublime-merge.viewFileHistory",
         "title": "View File History in Sublime Merge",
         "category": "Sublime Merge"
@@ -82,6 +87,7 @@
     ]
   },
   "activationEvents": [
+    "onCommand:history-in-sublime-merge.openRepository",
     "onCommand:history-in-sublime-merge.viewFileHistory",
     "onCommand:history-in-sublime-merge.viewLineHistory",
     "onCommand:history-in-sublime-merge.blameFile"


### PR DESCRIPTION
Hi mate! It's me again, after two years. Still using and loving your extension.

I often switch from VS Code to Sublime Merge, which I do with "View file history in Sublime Merge", but I have to hit `Escape` all the time, to close the Search in Sublime. So to improve that, I made this pull request which adds a command that only opens the repository in Sublime, not a particular file.

(Something else I'd like to do: fix the explorer context commands, which open the currently opened file, not the file righ-clicked in the explorer. But I don't want to hit you with a big PR, so I'll do that in a subsequent one.)